### PR TITLE
match created / expected properties file name

### DIFF
--- a/docker/properties-builder.sh
+++ b/docker/properties-builder.sh
@@ -13,7 +13,7 @@ then
         #for testing locally
         PROP_FILE=application.properties
 else 
-	PROP_FILE=config/hygieia-jenkins-build-collector.properties
+	PROP_FILE=config/application.properties
 fi
   
 if [ "$MONGO_PORT" != "" ]; then


### PR DESCRIPTION
Change name of the output application properties file to match what is expected by the CMD in Dockerfile
